### PR TITLE
Add SKILL.md with modern Go standards (1.22-1.26)

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -1,0 +1,664 @@
+---
+name: go-latest-version
+description: >
+  Enforces modern Go standards and idioms for Go 1.22 through 1.26. Use when writing,
+  reviewing, or modifying Go code to ensure the latest language features, standard library
+  APIs, and best practices are used. Prevents deprecated patterns and guides toward
+  idiomatic modern Go.
+license: Apache-2.0
+metadata:
+  author: FumingPower3925
+  version: "1.0"
+  go-versions: "1.22, 1.23, 1.24, 1.25, 1.26"
+---
+
+# Modern Go Standards (1.22 -- 1.26)
+
+You are writing Go code targeting the latest Go versions. Always prefer the most modern
+idiomatic pattern. If the project's `go.mod` specifies a version, respect that as the
+minimum feature set. When no version is specified, assume Go 1.26.
+
+For even more detailed examples, see [MODERN-PATTERNS.md](references/MODERN-PATTERNS.md).
+For full deprecation lists and GODEBUG settings, see [DEPRECATED.md](references/DEPRECATED.md).
+
+---
+
+## Critical Rules
+
+1. **Never use deprecated APIs** when a modern replacement exists.
+2. **Check go.mod version** before using version-gated features.
+3. **Use `range` over integers** instead of C-style `for` loops (Go 1.22+).
+4. **Use iterators** (`iter.Seq`, `iter.Seq2`) for sequences (Go 1.23+).
+5. **Use `errors.AsType[T]`** instead of `errors.As` (Go 1.26+).
+6. **Use `new(expr)`** for inline pointer creation (Go 1.26+).
+7. **Use `b.Loop()`** instead of `for range b.N` in benchmarks (Go 1.24+).
+8. **Use `t.Context()`** instead of manually creating cancelable contexts in tests (Go 1.24+).
+9. **Use `sync.WaitGroup.Go()`** instead of manual `Add`/`Done` patterns (Go 1.25+).
+10. **Use `crypto/rand.Text()`** for random tokens instead of custom generators (Go 1.24+).
+11. **Pass `nil` for the `rand` parameter** in crypto functions (Go 1.26+).
+12. **Use `runtime.AddCleanup`** instead of `runtime.SetFinalizer` (Go 1.24+).
+13. **Use `omitzero`** instead of `omitempty` for struct fields in JSON tags (Go 1.24+).
+14. **Use `math/rand/v2`** instead of `math/rand` (Go 1.22+).
+15. **Use `os.Root`** for directory-scoped filesystem access (Go 1.24+).
+16. **Remove loop variable capture hacks** (`v := v`) -- per-iteration scoping is automatic (Go 1.22+).
+
+---
+
+## Do This, Not That
+
+### Language & Syntax
+
+| Instead of (old) | Use (modern) | Since |
+|---|---|---|
+| `for i := 0; i < n; i++` | `for i := range n` | 1.22 |
+| `v := v` in loop closures | Remove it; loop vars are per-iteration | 1.22 |
+| `p := 42; foo(&p)` | `foo(new(42))` | 1.26 |
+| `errors.As(err, &target)` | `errors.AsType[*T](err)` | 1.26 |
+| Custom iterator callbacks | `iter.Seq[V]` / `iter.Seq2[K, V]` with `for range` | 1.23 |
+
+### Standard Library
+
+| Instead of (old) | Use (modern) | Since |
+|---|---|---|
+| `math/rand.Intn(n)` | `math/rand/v2.IntN(n)` | 1.22 |
+| `math/rand.Seed(...)` | Remove it; auto-seeded since 1.20, no-op since 1.24 | 1.22 |
+| `math/rand.Int31()` / `Int63()` | `math/rand/v2.Int32()` / `Int64()` | 1.22 |
+| `math/rand.Read(b)` | `crypto/rand.Read(b)` | 1.22 |
+| `rand.NewSource(seed)` | `rand.NewPCG(s1, s2)` or `rand.NewChaCha8(seed)` | 1.22 |
+| `fmt.Sprintf` for errors | `fmt.Errorf` (now equally efficient) | 1.26 |
+| `runtime.SetFinalizer` | `runtime.AddCleanup` | 1.24 |
+| `sort.Slice(s, less)` | `slices.SortFunc(s, cmp)` | 1.23 |
+| `strings.Split` in `for range` | `strings.SplitSeq` | 1.24 |
+| `strings.Fields` in `for range` | `strings.FieldsSeq` | 1.24 |
+| Manual contains loop | `slices.Contains(s, v)` | 1.21 |
+| `io.Discard` with `slog.NewTextHandler` | `slog.DiscardHandler` | 1.24 |
+| `slog.Group("k", attrs...)` with `[]slog.Attr` | `slog.GroupAttrs("k", attrs...)` | 1.25 |
+| Single `slog` handler | `slog.NewMultiHandler(h1, h2)` for fan-out | 1.26 |
+
+### Error Handling
+
+| Instead of (old) | Use (modern) | Since |
+|---|---|---|
+| `var target *T; errors.As(err, &target)` | `target, ok := errors.AsType[*T](err)` | 1.26 |
+| `errors.New("x")` vs `fmt.Errorf("x")` debate | Use either; `fmt.Errorf` now matches `errors.New` perf | 1.26 |
+
+### HTTP
+
+| Instead of (old) | Use (modern) | Since |
+|---|---|---|
+| Third-party router for method matching | `mux.HandleFunc("POST /path", h)` | 1.22 |
+| Third-party router for path params | `/items/{id}` with `r.PathValue("id")` | 1.22 |
+| Custom CSRF middleware | `http.CrossOriginProtection` | 1.25 |
+| `httputil.ReverseProxy.Director` | `httputil.ReverseProxy.Rewrite` | 1.26 |
+| Manual HTTP protocol negotiation | `Server.Protocols` / `Transport.Protocols` | 1.24 |
+
+### Testing
+
+| Instead of (old) | Use (modern) | Since |
+|---|---|---|
+| `for range b.N` | `for b.Loop()` | 1.24 |
+| `ctx, cancel := context.WithCancel(...)` in tests | `t.Context()` | 1.24 |
+| Manual working directory changes in tests | `t.Chdir(dir)` | 1.24 |
+| `time.Sleep` in concurrent tests | `testing/synctest.Test` with fake clock | 1.25 |
+| `testing/synctest.Run` | `testing/synctest.Test` | 1.25 |
+| `sink` variable to prevent optimization | `b.Loop()` keeps values alive | 1.24 |
+
+### Crypto
+
+| Instead of (old) | Use (modern) | Since |
+|---|---|---|
+| Custom random token generation | `crypto/rand.Text()` | 1.24 |
+| `ecdsa.GenerateKey(curve, rand.Reader)` | `ecdsa.GenerateKey(curve, nil)` | 1.26 |
+| `rsa.GenerateKey(rand.Reader, bits)` | `rsa.GenerateKey(nil, bits)` | 1.26 |
+| `golang.org/x/crypto/sha3` | `crypto/sha3` | 1.24 |
+| `golang.org/x/crypto/hkdf` | `crypto/hkdf` | 1.24 |
+| `golang.org/x/crypto/pbkdf2` | `crypto/pbkdf2` | 1.24 |
+| `EncryptPKCS1v15` | `EncryptOAEP` | 1.26 |
+| `cipher.NewGCM` + manual nonce | `cipher.NewGCMWithRandomNonce` | 1.24 |
+| SHA-1 certificates | SHA-256+ certificates (SHA-1 removed in 1.24) | 1.24 |
+| RSA keys < 1024 bits | RSA keys >= 2048 bits | 1.24 |
+
+### Filesystem
+
+| Instead of (old) | Use (modern) | Since |
+|---|---|---|
+| `os.Open` with path validation | `os.OpenRoot(dir)` + `root.Open(file)` | 1.24 |
+| Manual recursive directory copy | `os.CopyFS(dst, srcFS)` | 1.23 |
+
+### Concurrency
+
+| Instead of (old) | Use (modern) | Since |
+|---|---|---|
+| `wg.Add(1); go func() { defer wg.Done(); f() }()` | `wg.Go(f)` | 1.25 |
+| String deduplication via maps | `unique.Make(s)` for canonical handles | 1.23 |
+| Timer drain before Reset | `t.Stop(); t.Reset(d)` -- no drain needed | 1.23 |
+| `time.After` in loops | Still works (GC-safe since 1.23), but `NewTimer` + `Reset` is better | 1.23 |
+
+---
+
+## Inline Code Examples
+
+These examples cover the most common patterns. The agent should use these patterns
+whenever writing Go code, without needing to consult reference files.
+
+### Range over Integers (Go 1.22+)
+
+```go
+// OLD: for i := 0; i < n; i++ { process(i) }
+// NEW:
+for i := range n {
+    process(i)
+}
+```
+
+### Loop Variables Are Per-Iteration (Go 1.22+)
+
+```go
+// This is safe now -- each iteration gets its own `v`:
+for _, v := range values {
+    go func() {
+        fmt.Println(v) // unique per iteration, no data race
+    }()
+}
+// DELETE any `v := v` capture hacks -- they are no longer needed.
+```
+
+### new(expr) for Pointer Fields (Go 1.26+)
+
+```go
+type Config struct {
+    Port    *int    `json:"port,omitzero"`
+    Debug   *bool   `json:"debug,omitzero"`
+    Timeout *string `json:"timeout,omitzero"`
+}
+
+cfg := Config{
+    Port:    new(8080),
+    Debug:   new(true),
+    Timeout: new("30s"),
+}
+```
+
+### errors.AsType (Go 1.26+)
+
+```go
+// OLD:
+// var pathErr *fs.PathError
+// if errors.As(err, &pathErr) { ... }
+
+// NEW -- type-safe, no reflection, no panic risk:
+if pathErr, ok := errors.AsType[*fs.PathError](err); ok {
+    fmt.Println("path:", pathErr.Path)
+}
+
+// Multiple error types -- variables scoped to their blocks:
+if connErr, ok := errors.AsType[*net.OpError](err); ok {
+    handleNetworkError(connErr)
+} else if dnsErr, ok := errors.AsType[*net.DNSError](err); ok {
+    handleDNSError(dnsErr)
+}
+```
+
+### Iterators (Go 1.23+)
+
+```go
+// Define a single-value iterator:
+func Reversed[V any](s []V) iter.Seq[V] {
+    return func(yield func(V) bool) {
+        for i := len(s) - 1; i >= 0; i-- {
+            if !yield(s[i]) {
+                return
+            }
+        }
+    }
+}
+
+// Use with range:
+for v := range Reversed(mySlice) {
+    fmt.Println(v)
+}
+
+// Standard library iterators:
+for v := range slices.Values(s) { }           // values only
+for i, v := range slices.Backward(s) { }      // reverse
+for chunk := range slices.Chunk(s, 3) { }     // chunked
+for k := range maps.Keys(m) { }               // map keys
+s2 := slices.Collect(slices.Values(s))         // collect into slice
+s2 := slices.Sorted(slices.Values(s))          // collect + sort
+
+// Lazy string iteration (Go 1.24+):
+for line := range strings.Lines(text) { }         // line-by-line
+for part := range strings.SplitSeq(s, ",") { }    // lazy split
+for word := range strings.FieldsSeq(s) { }        // whitespace split
+```
+
+### math/rand/v2 (Go 1.22+)
+
+```go
+import "math/rand/v2"
+
+n := rand.IntN(100)           // random int in [0, 100)
+n := rand.N(max)              // generic -- works with any integer type
+d := rand.N(100*time.Millisecond) // works with time.Duration too
+u := rand.Uint64()            // random uint64
+// Default generator is ChaCha8 (cryptographically strong)
+// No need to seed -- auto-seeded
+```
+
+### HTTP Routing (Go 1.22+)
+
+```go
+mux := http.NewServeMux()
+mux.HandleFunc("GET /api/users", listUsers)
+mux.HandleFunc("POST /api/users", createUser)
+mux.HandleFunc("GET /api/users/{id}", func(w http.ResponseWriter, r *http.Request) {
+    id := r.PathValue("id")
+    user, err := db.GetUser(id)
+    // ...
+})
+mux.HandleFunc("GET /static/{path...}", func(w http.ResponseWriter, r *http.Request) {
+    path := r.PathValue("path") // matches entire remaining path
+    http.ServeFile(w, r, filepath.Join("static", path))
+})
+```
+
+### CSRF Protection (Go 1.25+)
+
+```go
+mux := http.NewServeMux()
+// ... register handlers ...
+
+protection := http.NewCrossOriginProtection()
+protection.AddTrustedOrigin("https://myapp.example.com")
+http.ListenAndServe(":8080", protection.Handler(mux))
+// Safe methods (GET, HEAD, OPTIONS) always pass through.
+```
+
+### Testing: b.Loop() (Go 1.24+)
+
+```go
+func BenchmarkProcess(b *testing.B) {
+    data := expensiveSetup() // runs once, not b.N times
+    for b.Loop() {           // no b.ResetTimer, no sink variable
+        process(data)        // compiler won't optimize away
+    }
+}
+```
+
+### Testing: t.Context() (Go 1.24+)
+
+```go
+func TestServer(t *testing.T) {
+    srv := startServer(t.Context()) // canceled after test, before cleanup
+    t.Cleanup(func() {
+        <-srv.Done() // wait for graceful shutdown
+    })
+    // ... test srv ...
+}
+```
+
+### Testing: synctest.Test (Go 1.25+)
+
+```go
+import "testing/synctest"
+
+func TestTimeout(t *testing.T) {
+    synctest.Test(t, func(t *testing.T) {
+        // Fake clock: time advances when all goroutines block
+        ch := make(chan int)
+        _, err := ReadWithTimeout(ch, time.Minute) // resolves instantly
+        if err == nil {
+            t.Fatal("expected timeout")
+        }
+    })
+}
+// Do NOT call t.Run, t.Parallel, or t.Deadline inside the bubble.
+```
+
+### Testing: t.Chdir, t.Attr, t.ArtifactDir
+
+```go
+func TestFileOps(t *testing.T) {
+    t.Chdir(t.TempDir()) // restored after test (Go 1.24+)
+    os.WriteFile("test.txt", []byte("hello"), 0o644)
+}
+
+func TestFeature(t *testing.T) {
+    t.Attr("team", "platform")        // metadata (Go 1.25+)
+    t.Attr("issue", "PROJ-1234")
+    dir := t.ArtifactDir()            // artifact output (Go 1.26+)
+    os.WriteFile(filepath.Join(dir, "debug.log"), logData, 0o644)
+}
+```
+
+### WaitGroup.Go (Go 1.25+)
+
+```go
+var wg sync.WaitGroup
+wg.Go(func() { result1 = fetchFromAPI() })
+wg.Go(func() { result2 = queryDatabase() })
+wg.Wait()
+```
+
+### unique Package (Go 1.23+)
+
+```go
+import "unique"
+
+type Server struct {
+    Zone unique.Handle[string]
+}
+func NewServer(zone string) Server {
+    return Server{Zone: unique.Make(zone)} // canonical reference
+}
+// Comparison is pointer-level fast: s1.Zone == s2.Zone
+```
+
+### os.Root -- Safe Filesystem (Go 1.24+)
+
+```go
+root, err := os.OpenRoot("/var/data")
+if err != nil { return err }
+defer root.Close()
+
+data, _ := root.ReadFile("config.json")      // scoped to /var/data
+root.WriteFile("out.json", data, 0o644)       // safe
+_, err = root.Open("../etc/passwd")            // ERROR: escapes root
+root.MkdirAll("a/b/c", 0o755)                 // Go 1.25+
+root.Rename("old.txt", "new.txt")             // Go 1.25+
+root.RemoveAll("temp")                        // Go 1.25+
+```
+
+### Crypto Patterns (Go 1.24+/1.26+)
+
+```go
+// Random token (Go 1.24+):
+token := crypto_rand.Text() // base32, 128+ bits
+
+// Key generation -- pass nil for rand (Go 1.26+):
+ecKey, _ := ecdsa.GenerateKey(elliptic.P256(), nil)
+rsaKey, _ := rsa.GenerateKey(nil, 2048)
+
+// SHA-3 (Go 1.24+):
+hash := sha3.Sum256(data)
+
+// GCM with auto nonce (Go 1.24+):
+block, _ := aes.NewCipher(key)
+aead, _ := cipher.NewGCMWithRandomNonce(block)
+ct := aead.Seal(nil, nil, plaintext, aad) // nonce auto-prepended
+
+// HKDF / PBKDF2 now in stdlib (Go 1.24+):
+dk := hkdf.Key(sha256.New, secret, salt, info, 32)
+dk := pbkdf2.Key([]byte(password), salt, 600000, 32, sha256.New)
+```
+
+### JSON: omitzero (Go 1.24+)
+
+```go
+type Event struct {
+    Name  string    `json:"name"`
+    Start time.Time `json:"start,omitzero"` // correctly omits zero time.Time
+    End   *Info     `json:"end,omitzero"`   // omits nil pointer
+}
+// omitzero uses IsZero() when available; omitempty uses legacy rules.
+// Prefer omitzero for struct types.
+```
+
+### Logging (Go 1.24+/1.25+/1.26+)
+
+```go
+// Discard handler (Go 1.24+):
+logger := slog.New(slog.DiscardHandler)
+
+// Multi-handler fan-out (Go 1.26+):
+logger := slog.New(slog.NewMultiHandler(
+    slog.NewJSONHandler(os.Stdout, nil),
+    slog.NewTextHandler(logFile, nil),
+))
+
+// GroupAttrs from a slice (Go 1.25+):
+attrs := []slog.Attr{slog.String("method", "GET"), slog.Int("status", 200)}
+logger.Info("request", slog.GroupAttrs("http", attrs...))
+```
+
+### Timer/Ticker (Go 1.23+)
+
+```go
+// Unreferenced timers are GC'd -- safe in select loops:
+select {
+case v := <-ch:
+    process(v)
+case <-time.After(timeout):
+    log.Warn("timeout")
+}
+
+// No drain before Reset (Go 1.23+):
+t := time.NewTimer(d)
+t.Stop()
+t.Reset(newDuration)
+<-t.C
+```
+
+### Reflect Iterators (Go 1.26+)
+
+```go
+typ := reflect.TypeFor[http.Client]()
+for f := range typ.Fields() {
+    fmt.Println(f.Name, f.Type)
+}
+for m := range typ.Methods() {
+    fmt.Println(m.Name, m.Type)
+}
+```
+
+### Tool Directives in go.mod (Go 1.24+)
+
+```bash
+go get -tool golang.org/x/tools/cmd/stringer
+go tool stringer -type=Color
+# No more tools.go with blank imports needed.
+```
+
+### go fix Modernization (Go 1.26+)
+
+```bash
+go fix ./...          # modernize all code
+go fix -diff ./...    # preview changes without applying
+go fix -rangeint .    # only specific fixer
+```
+
+Fixers include: `rangeint`, `bloop`, `waitgroup`, `omitzero`, `slicescontains`,
+`slicessort`, `minmax`, `stringscut`, `stringsseq`, `forvar`, `newexpr`.
+
+---
+
+## Feature Availability by Version
+
+### Go 1.22
+- Per-iteration loop variable scoping
+- `for i := range n` (range over integers)
+- `math/rand/v2` package
+- Enhanced `net/http.ServeMux` routing (methods, wildcards, `{param}`, `{path...}`, `{$}`)
+- `slices.Concat`, zeroing behavior for `slices.Delete`/`Compact`/`Replace`
+- `go/version` package
+- `database/sql.Null[T]` generic type
+- Range-over-func preview (`GOEXPERIMENT=rangefunc`)
+
+### Go 1.23
+- Range over function iterators (`iter.Seq`, `iter.Seq2`, `iter.Pull`)
+- `slices.All`, `Values`, `Backward`, `Collect`, `AppendSeq`, `Sorted`, `SortedFunc`, `Chunk`
+- `maps.All`, `Keys`, `Values`, `Insert`, `Collect`
+- `unique` package (value interning/canonicalization)
+- Timer/Ticker: GC-eligible without Stop; no stale values after Reset/Stop
+- `os.CopyFS`
+- `http.ParseCookie`, `http.ParseSetCookie`, `Cookie.Partitioned`
+- `slices.Repeat`
+- `structs` package (`structs.HostLayout`)
+
+### Go 1.24
+- Generic type aliases
+- `weak` package (weak pointers)
+- `runtime.AddCleanup` (replaces `SetFinalizer`)
+- Swiss Tables map implementation
+- `sync.Map` based on concurrent hash-trie
+- `os.Root` / `os.OpenRoot` (directory-scoped FS)
+- `testing.B.Loop()`, `T.Context()`, `B.Context()`, `T.Chdir()`, `B.Chdir()`
+- `testing/synctest` (experimental)
+- `slog.DiscardHandler`
+- `encoding.TextAppender`, `encoding.BinaryAppender`
+- `strings.Lines`, `SplitSeq`, `SplitAfterSeq`, `FieldsSeq`, `FieldsFuncSeq` (also in `bytes`)
+- `crypto/sha3`, `crypto/hkdf`, `crypto/pbkdf2`, `crypto/mlkem`
+- `crypto/rand.Text()`, `crypto/rand.Read` never fails
+- `cipher.NewGCMWithRandomNonce`
+- JSON `omitzero` struct tag
+- `http.Server.Protocols`, `http.Transport.Protocols`
+- Tool directives in `go.mod` (`go get -tool`)
+- `go build/test -json` flag
+- Build binary embeds VCS version info
+- FIPS 140-3 support (`GODEBUG=fips140=on|only`)
+
+### Go 1.25
+- `testing/synctest.Test` (GA, replaces experimental `Run`)
+- `encoding/json/v2` (experimental, `GOEXPERIMENT=jsonv2`)
+- Container-aware GOMAXPROCS (respects cgroup CPU limits)
+- Green Tea GC (experimental, `GOEXPERIMENT=greenteagc`)
+- `http.CrossOriginProtection` (CSRF protection)
+- `sync.WaitGroup.Go()`
+- `trace.FlightRecorder`
+- `os.Root` expanded methods (`Chmod`, `Chown`, `MkdirAll`, `RemoveAll`, `Rename`, `ReadFile`, `WriteFile`, `Symlink`, `Readlink`, `Link`)
+- `reflect.TypeAssert[T]`
+- `T.Attr()`, `T.Output()`, `B.Attr()`, `B.Output()`
+- `slog.GroupAttrs`
+- `hash.Cloner` interface
+- `io/fs.ReadLinkFS`
+- `runtime.SetDefaultGOMAXPROCS()`
+
+### Go 1.26
+- `new(expr)` -- `new` accepts expressions, not just types
+- Recursive generic type constraints
+- `errors.AsType[T]` -- generic, type-safe error checking
+- Green Tea GC enabled by default
+- Faster cgo (~30%), faster small allocations (~30%), optimized `io.ReadAll` (~2x)
+- `fmt.Errorf` performance matches `errors.New`
+- `crypto/hpke` (Hybrid Public Key Encryption, RFC 9180)
+- Reader-less crypto (rand parameter ignored; use `nil`)
+- `testing/cryptotest.SetGlobalRandom` for deterministic testing
+- `simd/archsimd` (experimental, `GOEXPERIMENT=simd`, amd64 only)
+- `runtime/secret` (experimental, `GOEXPERIMENT=runtimesecret`)
+- Goroutine leak profile (experimental, `GOEXPERIMENT=goroutineleakprofile`)
+- `bytes.Buffer.Peek(n)`
+- `reflect.Type.Fields()`, `Methods()`, `Ins()`, `Outs()` iterators
+- `reflect.Value.Fields()`, `Methods()` iterators
+- `slog.NewMultiHandler`
+- `T.ArtifactDir()`, `B.ArtifactDir()`
+- `net.Dialer.DialTCP/UDP/IP/Unix` with context
+- `netip.Prefix.Compare`
+- `os.Process.WithHandle`
+- `signal.NotifyContext` cause includes signal info
+- `httptest.Server.Client` redirects `example.com` to test server
+- `testing/cryptotest.SetGlobalRandom`
+- `go fix` overhauled with modernization analyzers
+- `cmd/doc` removed (use `go doc`)
+
+---
+
+## JSON Patterns
+
+### Current Stable (encoding/json v1)
+
+```go
+// Use omitzero for struct fields (Go 1.24+)
+type Event struct {
+    Name    string    `json:"name"`
+    Start   time.Time `json:"start,omitzero"`   // omits zero time.Time
+    Count   int       `json:"count,omitempty"`   // omits 0
+    Details *Info     `json:"details,omitzero"`  // omits nil pointer
+}
+```
+
+`omitzero` checks `IsZero()` if available, otherwise checks for the zero value of the type.
+`omitempty` uses legacy emptiness rules (0, "", nil, false, empty slice/map).
+Prefer `omitzero` for struct types, especially `time.Time`.
+
+### Experimental v2 (`GOEXPERIMENT=jsonv2`, Go 1.25+)
+
+Key behavioral differences from v1:
+- Nil slices marshal to `[]` (not `null`); use `FormatNilSliceAsNull(true)` for v1 behavior
+- Nil maps marshal to `{}` (not `null`); use `FormatNilMapAsNull(true)` for v1 behavior
+- Case-sensitive field matching by default; use `MatchCaseInsensitiveNames(true)` for v1 behavior
+- Duplicate fields rejected by default; use `AllowDuplicateNames(true)` for v1 behavior
+- Byte arrays marshal to base64 (not number arrays)
+- Unmarshaling is 2.7x -- 10.2x faster than v1
+
+---
+
+## HTTP Routing Patterns (Go 1.22+)
+
+```go
+mux := http.NewServeMux()
+
+mux.HandleFunc("GET /users", listUsers)           // method matching
+mux.HandleFunc("POST /users", createUser)          // GET also registers HEAD
+mux.HandleFunc("GET /users/{id}", getUser)         // path parameter
+mux.HandleFunc("DELETE /users/{id}", deleteUser)
+mux.HandleFunc("GET /files/{path...}", serveFile)  // wildcard rest
+mux.HandleFunc("GET /exact/{$}", exactOnly)        // exact match (no prefix)
+
+func getUser(w http.ResponseWriter, r *http.Request) {
+    id := r.PathValue("id")  // extract path parameter
+    // ...
+}
+```
+
+Precedence: more specific patterns win. Method patterns beat non-method patterns.
+Patterns with `{` and `}` are interpreted as wildcards; escape if needed.
+
+---
+
+## Timer/Ticker Patterns (Go 1.23+)
+
+```go
+// Safe: unreferenced timers are GC'd (Go 1.23+)
+select {
+case <-ch:
+    // handle
+case <-time.After(timeout):
+    // timeout
+}
+
+// Reuse timer safely -- no channel drain needed (Go 1.23+)
+t := time.NewTimer(d)
+// ... later ...
+t.Stop()
+t.Reset(newDuration)
+<-t.C
+```
+
+---
+
+## Key GODEBUG Settings
+
+| Setting | Default | Controls | Removal |
+|---|---|---|---|
+| `httpmuxgo121` | `0` | Revert to Go 1.21 ServeMux routing | -- |
+| `asynctimerchan` | `0` | Timer channel buffering (0=unbuffered) | Go 1.27 |
+| `randseednop` | `1` | `math/rand.Seed` is a no-op | -- |
+| `fips140` | `off` | FIPS 140-3 mode (`off`/`on`/`only`) | -- |
+| `cryptocustomrand` | `0` | Honor custom rand in crypto funcs | Future |
+| `httpcookiemaxnum` | `3000` | Max cookies per HTTP request | -- |
+| `containermaxprocs` | `1` | Cgroup CPU limits for GOMAXPROCS | -- |
+| `updatemaxprocs` | `1` | Auto-update GOMAXPROCS from cgroup | -- |
+
+---
+
+## Performance Notes
+
+- **Maps**: Swiss Tables since Go 1.24 (~30% faster for large maps, ~35% for pre-sized).
+- **sync.Map**: Hash-trie since Go 1.24 (~49% faster geomean, especially modifications).
+- **GC**: Green Tea GC default in Go 1.26 (10-40% less GC overhead).
+- **Allocations**: Size-specialized malloc in Go 1.26 (~30% faster small allocs).
+- **cgo**: ~30% less overhead in Go 1.26.
+- **io.ReadAll**: ~2x faster, ~50% less memory in Go 1.26.
+- **fmt.Errorf**: Now matches `errors.New` for non-formatted strings in Go 1.26.
+
+These are automatic -- no code changes needed.

--- a/references/DEPRECATED.md
+++ b/references/DEPRECATED.md
@@ -1,0 +1,332 @@
+# Deprecated Patterns and GODEBUG Reference
+
+This reference lists all deprecated patterns, removed features, and GODEBUG settings
+for Go 1.22 through Go 1.26. For the quick reference, see the main [SKILL.md](../SKILL.md).
+
+---
+
+## Table of Contents
+
+- [Deprecated APIs and Their Replacements](#deprecated-apis-and-their-replacements)
+- [Removed Features](#removed-features)
+- [GODEBUG Settings](#godebug-settings)
+- [Breaking Behavioral Changes](#breaking-behavioral-changes)
+- [Security-Related Changes](#security-related-changes)
+- [Platform Changes](#platform-changes)
+
+---
+
+## Deprecated APIs and Their Replacements
+
+### math/rand (replaced by math/rand/v2, Go 1.22)
+
+| Deprecated | Replacement | Notes |
+|---|---|---|
+| `math/rand.Seed(n)` | Remove entirely | Auto-seeded since 1.20; no-op since 1.24 |
+| `math/rand.Read(b)` | `crypto/rand.Read(b)` | Deprecated since 1.20 |
+| `math/rand.Intn(n)` | `math/rand/v2.IntN(n)` | Capital N convention |
+| `math/rand.Int31()` | `math/rand/v2.Int32()` | Consistent naming |
+| `math/rand.Int31n(n)` | `math/rand/v2.Int32N(n)` | |
+| `math/rand.Int63()` | `math/rand/v2.Int64()` | |
+| `math/rand.Int63n(n)` | `math/rand/v2.Int64N(n)` | |
+| `math/rand.NewSource(seed)` | `rand.NewPCG(s1, s2)` or `rand.NewChaCha8(seed)` | Named generators |
+| `math/rand.Source64` interface | Single `Uint64` method on `Source` | No separate interface in v2 |
+| `golang.org/x/exp/rand` | `math/rand/v2` | Experimental superseded |
+
+New in v2: `rand.N[T](max)` generic function, `UintN`, `Uint32`, `Uint64`, etc.
+Default generator: ChaCha8 (cryptographically strong).
+
+### runtime.SetFinalizer (replaced by AddCleanup, Go 1.24)
+
+| Deprecated | Replacement | Notes |
+|---|---|---|
+| `runtime.SetFinalizer(obj, fn)` | `runtime.AddCleanup(obj, fn, arg)` | New code should use AddCleanup |
+
+AddCleanup advantages:
+- Multiple cleanups per object (SetFinalizer allows only one)
+- No object resurrection (cleanup receives arg, not the object)
+- Works with interior pointers
+- Cycles of objects with cleanups can be GC'd
+- Cleaner API with explicit argument passing
+
+### crypto/rsa Encryption (Go 1.26)
+
+| Deprecated | Replacement | Notes |
+|---|---|---|
+| `rsa.EncryptPKCS1v15(rand, pub, msg)` | `rsa.EncryptOAEP(hash, rand, pub, msg, label)` | PKCS#1 v1.5 is unsafe |
+| `rsa.DecryptPKCS1v15(rand, priv, ct)` | `rsa.DecryptOAEP(hash, rand, priv, ct, label)` | |
+| `rsa.DecryptPKCS1v15SessionKey(...)` | OAEP-based alternatives | |
+| `rsa.GenerateMultiPrimeKey(...)` | `rsa.GenerateKey(nil, bits)` | Multi-prime deprecated |
+
+### crypto/ecdsa Fields (Go 1.26)
+
+| Deprecated | Notes |
+|---|---|
+| `ecdsa.PublicKey.X`, `ecdsa.PublicKey.Y` (big.Int) | Use alternative representations |
+| `ecdsa.PrivateKey.D` (big.Int) | Use alternative representations |
+
+### crypto Random Readers (Go 1.26)
+
+All crypto functions that accepted `io.Reader` for randomness now **ignore** the
+parameter and always use the system's secure random source:
+
+```go
+// These all ignore the rand parameter -- pass nil
+ecdsa.GenerateKey(elliptic.P256(), nil)
+rsa.GenerateKey(nil, 2048)
+ecdh.P256().GenerateKey(nil)
+rand.Prime(nil, 64)
+ed25519.GenerateKey(nil)
+```
+
+Exception: `ed25519.GenerateKey(rand)` still uses the reader if non-nil.
+
+Use `testing/cryptotest.SetGlobalRandom(t, seed)` for deterministic testing.
+Revert with `GODEBUG=cryptocustomrand=1` (temporary, will be removed).
+
+### HTTP
+
+| Deprecated | Replacement | Since |
+|---|---|---|
+| `httputil.ReverseProxy.Director` | `httputil.ReverseProxy.Rewrite` | 1.26 |
+
+### crypto/cipher
+
+| Deprecated | Replacement | Since |
+|---|---|---|
+| `cipher.NewOFB` | Modern AEAD modes (GCM) | 1.24 |
+| `cipher.NewCFBEncrypter` | Modern AEAD modes (GCM) | 1.24 |
+| `cipher.NewCFBDecrypter` | Modern AEAD modes (GCM) | 1.24 |
+
+### Other Deprecations
+
+| Deprecated | Replacement | Since |
+|---|---|---|
+| `runtime.GOROOT()` | Use `go env GOROOT` or build info | 1.24 |
+| `testing/synctest.Run` | `testing/synctest.Test` | 1.25 |
+| `go/parser.ParseDir` | -- | 1.25 |
+| `go/ast.FilterPackage` | -- | 1.25 |
+| `go/ast.PackageExports` | -- | 1.25 |
+| `go/ast.MergePackageFiles` | -- | 1.25 |
+| `go/ast.MergeMode` type | -- | 1.25 |
+| `crypto/elliptic.Inverse` | -- | Removed 1.25 |
+| `crypto/elliptic.CombinedMult` | -- | Removed 1.25 |
+
+---
+
+## Removed Features
+
+### Go 1.24
+- SHA-1 signature verification in `crypto/x509` (`x509sha1` GODEBUG removed)
+- `go get` in legacy GOPATH mode (removed in 1.22)
+
+### Go 1.25
+- `crypto/elliptic.Inverse` and `CombinedMult` (undocumented methods)
+- `runtimecontentionstacks` GODEBUG setting
+
+### Go 1.26
+- `cmd/doc` and `go tool doc` (use `go doc` instead)
+- `windows/arm` (32-bit) port
+- `signext` and `satconv` GOWASM settings (now unconditional)
+- All historical `go fix` fixers (replaced by analysis-based fixers)
+- `testing/synctest.Run` (use `Test` instead)
+
+### Scheduled for Removal in Go 1.27
+- `GODEBUG=asynctimerchan` (timer channel buffering)
+- `GODEBUG=gotypesalias` (type alias behavior)
+- `GOEXPERIMENT=nogreenteagc` (Green Tea GC opt-out)
+- `GODEBUG=tlsunsafeekm`
+- `GODEBUG=tlsrsakex`
+- `GODEBUG=tls10server`
+- `GODEBUG=tls3des`
+- `GODEBUG=x509keypairleaf`
+- `GODEBUG=cryptocustomrand`
+- `GODEBUG=urlstrictcolons`
+
+---
+
+## GODEBUG Settings
+
+### Go 1.22 Settings
+
+| Setting | Default | Description |
+|---|---|---|
+| `httpmuxgo121=1` | 0 (new routing) | Revert to Go 1.21 ServeMux routing |
+| `tlsmaxrsasize=N` | 8192 | Max RSA key size in TLS handshakes |
+| `tls10server=1` | 0 (TLS 1.2 min) | Allow TLS 1.0/1.1 for servers |
+| `tlsrsakex=1` | 0 (disabled) | Enable RSA key exchange in TLS |
+| `httplaxcontentlength=1` | 0 | Lax Content-Length parsing |
+| `disablethp=1` | 0 | Disable transparent huge pages |
+
+### Go 1.23 Settings
+
+| Setting | Default | Description |
+|---|---|---|
+| `asynctimerchan=1` | 0 (unbuffered) | Timer channel uses old buffered behavior |
+| `tls3des=1` | 0 (disabled) | Enable 3DES cipher suites |
+| `x509negativeserial=1` | 0 (reject) | Allow negative certificate serial numbers |
+| `x509keypairleaf=0` | 1 (populate) | Don't populate X509KeyPair Leaf field |
+| `winsymlink=0` | 1 | Disable Windows symlink mode bits |
+| `winreadlinkvolume=0` | 1 | Disable Windows Readlink volume normalization |
+
+### Go 1.24 Settings
+
+| Setting | Default | Description |
+|---|---|---|
+| `fips140=off\|on\|only` | off | FIPS 140-3 mode |
+| `randseednop=0` | 1 (no-op) | Make `math/rand.Seed` functional again |
+| `rsa1024min=0` | 1 (enforce) | Allow RSA keys < 1024 bits |
+| `x509rsacrt=0` | 1 (validate) | Skip CRT parameter validation |
+| `x509usepolicies=0` | 1 | Use old `PolicyIdentifiers` field |
+| `gotestjsonbuildtext=1` | 0 (JSON) | `go test -json` build error format |
+| `multipathtcp=N` | 2 (listeners) | Multipath TCP enablement |
+| `tlsmlkem=0` | 1 (enabled) | Disable post-quantum key exchange |
+
+### Go 1.25 Settings
+
+| Setting | Default | Description |
+|---|---|---|
+| `containermaxprocs=0` | 1 (enabled) | Ignore cgroup CPU limits for GOMAXPROCS |
+| `updatemaxprocs=0` | 1 (enabled) | Don't auto-update GOMAXPROCS |
+| `tlssha1=1` | 0 (disabled) | Allow SHA-1 in TLS 1.2 handshakes |
+| `x509sha256skid=0` | 1 (SHA-256) | Use SHA-1 for SubjectKeyId |
+| `allowmultiplevcs=1` | 0 (disabled) | Allow multiple VCS metadata dirs |
+| `decoratemappings=0` | 1 (enabled) | Disable OS memory mapping annotations |
+| `embedfollowsymlinks=1` | 0 (disabled) | Follow symlinks in embed |
+
+### Go 1.26 Settings
+
+| Setting | Default | Description |
+|---|---|---|
+| `cryptocustomrand=1` | 0 (ignore) | Honor custom random reader in crypto funcs |
+| `httpcookiemaxnum=N` | 3000 | Max cookies per HTTP request |
+| `urlmaxqueryparams=N` | 10000 | Max URL query parameters |
+| `urlstrictcolons=0` | 1 (strict) | Allow malformed URLs with colons in host |
+| `tlssecpmlkem=0` | 1 (enabled) | Disable SecP MLKEM post-quantum KEM |
+
+### GOEXPERIMENT Flags
+
+| Flag | Since | Status | Description |
+|---|---|---|---|
+| `GOEXPERIMENT=rangefunc` | 1.22 | Stable in 1.23 | Range over function iterators |
+| `GOEXPERIMENT=aliastypeparams` | 1.23 | Stable in 1.24 | Generic type aliases |
+| `GOEXPERIMENT=synctest` | 1.24 | Stable in 1.25 | testing/synctest package |
+| `GOEXPERIMENT=jsonv2` | 1.25 | Experimental | encoding/json/v2 |
+| `GOEXPERIMENT=greenteagc` | 1.25 | Default in 1.26 | Green Tea garbage collector |
+| `GOEXPERIMENT=nogreenteagc` | 1.26 | Opt-out (removed in 1.27) | Disable Green Tea GC |
+| `GOEXPERIMENT=simd` | 1.26 | Experimental | SIMD/vectorized operations (amd64) |
+| `GOEXPERIMENT=runtimesecret` | 1.26 | Experimental | secret.Do for forward secrecy |
+| `GOEXPERIMENT=goroutineleakprofile` | 1.26 | Experimental | Goroutine leak detection |
+| `GOEXPERIMENT=nosizespecializedmalloc` | 1.26 | Opt-out (removed in 1.27) | Disable optimized small allocs |
+| `GOEXPERIMENT=norandomizedheapbase64` | 1.26 | Opt-out | Disable heap address randomization |
+
+---
+
+## Breaking Behavioral Changes
+
+### Go 1.22
+- **Loop variable scoping**: Each `for` loop iteration creates new variables (controlled by go.mod version).
+- **ServeMux routing**: Patterns with `{` and `}` are now interpreted as wildcards. Set `httpmuxgo121=1` to revert.
+- **slices.Insert**: Now always panics if index is out of range (even with zero elements to insert).
+- **slices.Delete/Compact/Replace**: Now zero elements between new and old length.
+
+### Go 1.23
+- **Timer/Ticker channels**: Unbuffered (capacity 0). No stale values after Stop/Reset. Unreferenced timers/tickers are GC-eligible. Controlled by go.mod version.
+- **`//go:linkname` restrictions**: Linker disallows referencing unmarked internal stdlib symbols.
+- **macOS**: Minimum macOS 11 Big Sur required.
+
+### Go 1.24
+- **crypto/x509**: SHA-1 signature verification removed entirely.
+- **crypto/rsa**: Keys < 1024 bits rejected by default.
+- **math/rand.Seed**: Becomes a no-op globally.
+- **Swiss Tables**: Map implementation changed. `reflect.DeepEqual` on `sync.Map` may differ.
+- **os.Root**: `Root.Open("../")` initially allowed parent directory access; fixed in 1.24.3.
+
+### Go 1.25
+- **SHA-1 in TLS 1.2**: Disabled by default per RFC 9155.
+- **SubjectKeyId**: `CreateCertificate` uses SHA-256 instead of SHA-1.
+- **testing/synctest**: `Run` function deprecated; use `Test`.
+- **testing.AllocsPerRun**: Panics if parallel tests are running.
+
+### Go 1.26
+- **image/jpeg**: New encoder/decoder may produce different bit-for-bit output.
+- **net/url.Parse**: Rejects malformed URLs with colons in host.
+- **Crypto random readers**: Ignored in most crypto functions.
+- **net/http cookies**: Use `Request.Host` for scoping.
+- **cmd/doc**: Removed (use `go doc`).
+
+---
+
+## Security-Related Changes
+
+### Crypto Minimums
+| Requirement | Since | Override |
+|---|---|---|
+| TLS 1.2 minimum for servers | 1.22 | `tls10server=1` |
+| RSA key exchange disabled | 1.22 | `tlsrsakex=1` |
+| 3DES cipher suites disabled | 1.23 | `tls3des=1` |
+| SHA-1 X.509 signatures removed | 1.24 | None (permanently removed) |
+| RSA minimum 1024-bit keys | 1.24 | `rsa1024min=0` |
+| SHA-1 in TLS 1.2 handshakes disabled | 1.25 | `tlssha1=1` |
+| PKCS#1 v1.5 encryption deprecated | 1.26 | Use OAEP instead |
+| Custom crypto randomness ignored | 1.26 | `cryptocustomrand=1` |
+
+### Post-Quantum Cryptography
+| Feature | Since | Override |
+|---|---|---|
+| X25519MLKEM768 in TLS | 1.24 | `tlsmlkem=0` |
+| `crypto/mlkem` package (FIPS 203) | 1.24 | -- |
+| SecP256r1MLKEM768, SecP384r1MLKEM1024 in TLS | 1.26 | `tlssecpmlkem=0` |
+| `crypto/hpke` (RFC 9180) | 1.26 | -- |
+
+### HTTP Cookie Limit (Go 1.26)
+`net/http` now limits cookies to 3,000 per request to prevent memory exhaustion
+(CVE-2025-58186). Configurable via `GODEBUG=httpcookiemaxnum=N`.
+
+### HTTP URL Query Limit (Go 1.26)
+URL query parameter count limited to 10,000 by default.
+Configurable via `GODEBUG=urlmaxqueryparams=N`.
+
+---
+
+## Platform Changes
+
+### Go 1.26 Platform Notes
+| Platform | Change |
+|---|---|
+| macOS 12 Monterey | Last supported in Go 1.26. Go 1.27 requires macOS 13+ |
+| linux/riscv64 | Race detector now supported |
+| s390x | Register-based function calling |
+| windows/arm (32-bit) | Removed |
+| freebsd/riscv64 | Broken (issue #76475) |
+| PowerPC ELFv1 | Last supported in Go 1.26. Go 1.27 switches to ELFv2 |
+| WebAssembly | Sign extension and non-trapping float-to-int mandatory |
+| windows/arm64 | cgo internal linking supported |
+
+### Minimum Requirements
+| Requirement | Version |
+|---|---|
+| macOS | 11 Big Sur (1.23+), 13 Ventura (1.27+) |
+| Linux kernel | 3.2+ (since 1.24) |
+| Bootstrap compiler | Go 1.24.6+ (for building 1.26) |
+
+---
+
+## Notable CVEs Fixed in Patch Releases
+
+These are the most impactful security fixes across 1.22.x -- 1.26.x patch releases
+that may affect application behavior:
+
+| CVE | Version | Impact |
+|---|---|---|
+| CVE-2023-45288 | 1.22.2 | HTTP/2 continuation flood (CPU exhaustion) |
+| CVE-2024-24790 | 1.22.4 | `netip.Is*` methods wrong for IPv4-mapped IPv6 |
+| CVE-2024-24791 | 1.22.5 | HTTP/1.1 Expect: 100-continue denial of service |
+| CVE-2024-34156 | 1.22.7/1.23.1 | encoding/gob stack exhaustion |
+| CVE-2024-45336 | 1.22.11/1.23.5 | HTTP sensitive header restoration after redirect |
+| CVE-2025-22871 | 1.23.8/1.24.2 | HTTP request smuggling via bare LF in chunks |
+| CVE-2025-22873 | 1.24.3 | os.Root parent directory escape |
+| CVE-2025-4674 | 1.23.11/1.24.5 | VCS command execution in go command |
+| CVE-2025-58186 | 1.24.8/1.25.2 | HTTP cookie parsing memory exhaustion |
+| CVE-2025-61732 | 1.24.13/1.25.7 | cgo code smuggling via comments |
+| CVE-2025-68121 | 1.24.12/1.25.6 | TLS session ticket key reuse |

--- a/references/MODERN-PATTERNS.md
+++ b/references/MODERN-PATTERNS.md
@@ -1,0 +1,825 @@
+# Modern Go Patterns -- Detailed Examples
+
+This reference provides detailed code examples for modern Go patterns introduced in
+Go 1.22 through Go 1.26. For the quick reference, see the main [SKILL.md](../SKILL.md).
+
+---
+
+## Table of Contents
+
+- [Error Handling](#error-handling)
+- [Iteration](#iteration)
+- [Testing](#testing)
+- [HTTP](#http)
+- [JSON](#json)
+- [Concurrency](#concurrency)
+- [Cryptography](#cryptography)
+- [Filesystem](#filesystem)
+- [Logging](#logging)
+- [Modules and Tooling](#modules-and-tooling)
+- [Reflection](#reflection)
+- [Performance Patterns](#performance-patterns)
+
+---
+
+## Error Handling
+
+### errors.AsType (Go 1.26+)
+
+Generic, type-safe, reflection-free replacement for `errors.As`:
+
+```go
+// Single error type check
+if pathErr, ok := errors.AsType[*fs.PathError](err); ok {
+    fmt.Println("path:", pathErr.Path)
+}
+
+// Multiple error type checks -- variables scoped to their blocks
+if connErr, ok := errors.AsType[*net.OpError](err); ok {
+    fmt.Println("network op failed:", connErr.Op)
+} else if dnsErr, ok := errors.AsType[*net.DNSError](err); ok {
+    fmt.Println("DNS failed:", dnsErr.Name)
+} else {
+    fmt.Println("unknown error:", err)
+}
+```
+
+`errors.AsType` is faster (~30ns vs ~96ns), allocates less (1 vs 2 allocs), and
+gives compile-time errors instead of runtime panics for incorrect types.
+
+### fmt.Errorf (Go 1.26 optimization)
+
+```go
+// Both are now equally efficient for plain strings:
+return errors.New("connection failed")
+return fmt.Errorf("connection failed")
+
+// Use fmt.Errorf for wrapping (always preferred):
+return fmt.Errorf("reading config %s: %w", path, err)
+
+// Wrap multiple errors (Go 1.20+):
+return fmt.Errorf("cleanup failed: %w; also: %w", err1, err2)
+```
+
+---
+
+## Iteration
+
+### Range over Integers (Go 1.22+)
+
+```go
+// Countdown
+for i := range 10 {
+    fmt.Println(10 - i)
+}
+
+// Generate a slice
+s := make([]int, 0, n)
+for i := range n {
+    s = append(s, i*i)
+}
+```
+
+### Loop Variable Scoping (Go 1.22+)
+
+```go
+// This is now safe -- each iteration gets its own variable:
+for _, v := range values {
+    go func() {
+        process(v)  // v is unique per iteration
+    }()
+}
+
+// Remove old workarounds:
+// BAD (unnecessary since 1.22):
+for _, v := range values {
+    v := v  // DELETE THIS LINE
+    go func() { process(v) }()
+}
+```
+
+### Iterators (Go 1.23+)
+
+#### Defining Iterators
+
+```go
+// Single-value iterator
+func Fibonacci(max int) iter.Seq[int] {
+    return func(yield func(int) bool) {
+        a, b := 0, 1
+        for a < max {
+            if !yield(a) {
+                return
+            }
+            a, b = b, a+b
+        }
+    }
+}
+
+// Two-value iterator
+func Enumerate[T any](s []T) iter.Seq2[int, T] {
+    return func(yield func(int, T) bool) {
+        for i, v := range s {
+            if !yield(i, v) {
+                return
+            }
+        }
+    }
+}
+
+// Usage
+for n := range Fibonacci(100) {
+    fmt.Println(n)
+}
+```
+
+#### Pull Iterators (Go 1.23+)
+
+```go
+next, stop := iter.Pull(Fibonacci(100))
+defer stop()
+
+for {
+    v, ok := next()
+    if !ok {
+        break
+    }
+    fmt.Println(v)
+}
+```
+
+#### Standard Library Iterators
+
+```go
+// Slices (Go 1.23+)
+for i, v := range slices.All(s) { }       // index + value
+for v := range slices.Values(s) { }        // values only
+for i, v := range slices.Backward(s) { }   // reverse order
+s2 := slices.Collect(seq)                   // collect into slice
+s2 := slices.Sorted(seq)                    // collect + sort
+s2 := slices.AppendSeq(existing, seq)       // append from iterator
+for chunk := range slices.Chunk(s, 3) { }  // chunked iteration
+
+// Maps (Go 1.23+)
+for k, v := range maps.All(m) { }          // all pairs
+for k := range maps.Keys(m) { }            // keys only
+for v := range maps.Values(m) { }          // values only
+maps.Insert(dst, maps.All(src))             // merge maps
+m2 := maps.Collect(seq2)                    // collect into map
+
+// Strings/Bytes (Go 1.24+)
+for line := range strings.Lines(s) { }           // line-by-line
+for part := range strings.SplitSeq(s, ",") { }   // lazy split
+for part := range strings.SplitAfterSeq(s, ",") { }
+for word := range strings.FieldsSeq(s) { }       // whitespace split
+for word := range strings.FieldsFuncSeq(s, f) { }
+
+// sync.Map (Go 1.23+ implicit range)
+var m sync.Map
+for key, val := range m.Range {
+    fmt.Println(key, val)
+}
+```
+
+---
+
+## Testing
+
+### b.Loop() Benchmarks (Go 1.24+)
+
+```go
+func BenchmarkProcess(b *testing.B) {
+    data := expensiveSetup()  // runs once, not b.N times
+    // No b.ResetTimer needed -- only the loop body is timed
+    // No sink variable needed -- compiler won't optimize away
+    for b.Loop() {
+        process(data)
+    }
+}
+```
+
+### t.Context() (Go 1.24+)
+
+```go
+func TestServer(t *testing.T) {
+    // Context is canceled just before Cleanup functions run
+    srv := startServer(t.Context())
+    t.Cleanup(func() {
+        <-srv.Done()  // wait for server shutdown after ctx cancel
+    })
+
+    resp, err := srv.Get("/health")
+    if err != nil {
+        t.Fatal(err)
+    }
+    // ...
+}
+```
+
+### t.Chdir() (Go 1.24+)
+
+```go
+func TestFileOps(t *testing.T) {
+    t.Chdir(t.TempDir())  // restored automatically after test
+    os.WriteFile("test.txt", []byte("hello"), 0o644)
+    // ...
+}
+```
+
+### synctest.Test (Go 1.25+)
+
+```go
+import "testing/synctest"
+
+func TestTimeout(t *testing.T) {
+    synctest.Test(t, func(t *testing.T) {
+        // Time is fake -- midnight UTC 2000-01-01
+        // Time advances when all goroutines in the bubble block
+
+        ch := make(chan int)
+        _, err := ReadWithTimeout(ch, time.Minute)  // instant!
+        if err == nil {
+            t.Fatal("expected timeout")
+        }
+    })
+}
+
+func TestConcurrent(t *testing.T) {
+    synctest.Test(t, func(t *testing.T) {
+        var ready bool
+        go func() {
+            ready = true
+            time.Sleep(time.Second)
+        }()
+
+        synctest.Wait()  // wait for all goroutines to block
+        // ready is guaranteed true here
+
+        // Advance time -- sleep completes instantly
+    })
+}
+```
+
+Note: Do not call `t.Run`, `t.Parallel`, or `t.Deadline` inside the bubble.
+
+### t.Attr() (Go 1.25+)
+
+```go
+func TestFeature(t *testing.T) {
+    t.Attr("team", "platform")
+    t.Attr("issue", "PROJ-1234")
+    // Appears in JSON output as {"Action":"attr","Key":"team","Value":"platform"}
+}
+```
+
+### t.ArtifactDir() (Go 1.26+)
+
+```go
+func TestComplex(t *testing.T) {
+    dir := t.ArtifactDir()
+    os.WriteFile(filepath.Join(dir, "debug.log"), logData, 0o644)
+}
+// Run: go test -artifacts -outputdir=/tmp/results ./...
+```
+
+### t.Output() (Go 1.25+)
+
+```go
+func TestWithAppLog(t *testing.T) {
+    logger := slog.New(slog.NewTextHandler(t.Output(), nil))
+    logger.Info("app log goes to test output")
+}
+```
+
+### Deterministic Crypto Testing (Go 1.26+)
+
+```go
+import "testing/cryptotest"
+
+func TestDeterministic(t *testing.T) {
+    cryptotest.SetGlobalRandom(t, 42)  // seed for reproducibility
+    // All crypto operations are deterministic for this test
+    key, _ := ecdsa.GenerateKey(elliptic.P256(), nil)
+    // Same key every run
+}
+```
+
+---
+
+## HTTP
+
+### Enhanced Routing (Go 1.22+)
+
+```go
+mux := http.NewServeMux()
+
+// Method matching (GET also registers HEAD)
+mux.HandleFunc("GET /api/users", listUsers)
+mux.HandleFunc("POST /api/users", createUser)
+
+// Path parameters
+mux.HandleFunc("GET /api/users/{id}", func(w http.ResponseWriter, r *http.Request) {
+    id := r.PathValue("id")
+    // ...
+})
+
+// Wildcard catch-all (must be at end)
+mux.HandleFunc("GET /static/{path...}", func(w http.ResponseWriter, r *http.Request) {
+    path := r.PathValue("path")  // e.g., "css/style.css"
+    // ...
+})
+
+// Exact match (no prefix matching)
+mux.HandleFunc("GET /health/{$}", healthCheck)
+// Matches /health/ but NOT /health/detailed
+```
+
+### CSRF Protection (Go 1.25+)
+
+```go
+mux := http.NewServeMux()
+mux.HandleFunc("GET /form", showForm)
+mux.HandleFunc("POST /submit", handleSubmit)
+
+protection := http.NewCrossOriginProtection()
+protection.AddTrustedOrigin("https://myapp.example.com")
+
+// Safe methods (GET, HEAD, OPTIONS) always pass
+// Requests without Sec-Fetch-Site or Origin also pass (by design)
+http.ListenAndServe(":8080", protection.Handler(mux))
+```
+
+### Protocol Configuration (Go 1.24+)
+
+```go
+// Server
+srv := &http.Server{Handler: mux}
+srv.Protocols = new(http.Protocols)
+srv.Protocols.SetHTTP1(true)
+srv.Protocols.SetHTTP2(true)
+
+// Client
+t := http.DefaultTransport.(*http.Transport).Clone()
+t.Protocols = new(http.Protocols)
+t.Protocols.SetHTTP1(true)
+t.Protocols.SetHTTP2(true)
+client := &http.Client{Transport: t}
+```
+
+### Cookie Parsing (Go 1.23+)
+
+```go
+// Parse Cookie header
+cookies, err := http.ParseCookie("session=abc; theme=dark")
+
+// Parse Set-Cookie header
+cookie, err := http.ParseSetCookie("session=abc; Secure; Partitioned; Path=/")
+fmt.Println(cookie.Partitioned)  // true
+
+// Named cookies from request
+cookies := r.CookiesNamed("session")
+```
+
+---
+
+## JSON
+
+### omitzero (Go 1.24+)
+
+```go
+type Event struct {
+    Name    string     `json:"name"`
+    Start   time.Time  `json:"start,omitzero"`   // omits zero time.Time correctly
+    End     *time.Time `json:"end,omitzero"`      // omits nil
+    Count   int        `json:"count,omitempty"`   // omits 0
+}
+
+// Custom IsZero:
+type Status struct {
+    Code int
+}
+func (s Status) IsZero() bool { return s.Code == 0 }
+
+type Response struct {
+    Status Status `json:"status,omitzero"`  // uses IsZero()
+}
+```
+
+### json/v2 (experimental, Go 1.25+)
+
+Build with `GOEXPERIMENT=jsonv2`.
+
+```go
+import "encoding/json/v2"
+import "encoding/json/jsontext"
+
+// MarshalWrite / UnmarshalRead (stream I/O)
+json.MarshalWrite(writer, value)
+json.UnmarshalRead(reader, &value)
+
+// Streaming encode/decode
+enc := jsontext.NewEncoder(writer)
+json.MarshalEncode(enc, value)
+
+dec := jsontext.NewDecoder(reader)
+json.UnmarshalDecode(dec, &value)
+
+// Options
+b, _ := json.Marshal(val,
+    json.OmitZeroStructFields(true),
+    json.StringifyNumbers(true),
+    jsontext.WithIndent("  "),
+)
+
+// New tags
+type Person struct {
+    Name    string  `json:"name"`
+    Birth   time.Time `json:"birth,format:DateOnly"`  // yyyy-mm-dd
+    Address Address `json:",inline"`                   // flatten nested struct
+    Extra   map[string]any `json:",unknown"`           // catch-all
+}
+
+// Custom marshalers without custom types
+boolMarshaler := json.MarshalToFunc(
+    func(enc *jsontext.Encoder, val bool) error {
+        if val { return enc.WriteToken(jsontext.String("yes")) }
+        return enc.WriteToken(jsontext.String("no"))
+    },
+)
+b, _ := json.Marshal(data, json.WithMarshalers(boolMarshaler))
+```
+
+---
+
+## Concurrency
+
+### WaitGroup.Go (Go 1.25+)
+
+```go
+var wg sync.WaitGroup
+
+wg.Go(func() {
+    result1 = fetchFromAPI()
+})
+wg.Go(func() {
+    result2 = queryDatabase()
+})
+
+wg.Wait()
+// Both results ready
+```
+
+### unique Package (Go 1.23+)
+
+```go
+import "unique"
+
+// Intern strings for memory efficiency
+type Request struct {
+    Method unique.Handle[string]
+    Host   unique.Handle[string]
+}
+
+func NewRequest(method, host string) Request {
+    return Request{
+        Method: unique.Make(method),
+        Host:   unique.Make(host),
+    }
+}
+
+// Fast comparison (pointer-level)
+r1.Method == r2.Method
+```
+
+### Weak Pointers (Go 1.24+)
+
+```go
+import "weak"
+
+type Cache[K comparable, V any] struct {
+    mu    sync.Mutex
+    items map[K]weak.Pointer[V]
+}
+
+func (c *Cache[K, V]) Get(key K) *V {
+    c.mu.Lock()
+    defer c.mu.Unlock()
+    if wp, ok := c.items[key]; ok {
+        return wp.Value()  // nil if GC'd
+    }
+    return nil
+}
+
+func (c *Cache[K, V]) Set(key K, val *V) {
+    c.mu.Lock()
+    defer c.mu.Unlock()
+    c.items[key] = weak.Make(val)
+    runtime.AddCleanup(val, func(k K) {
+        c.mu.Lock()
+        delete(c.items, k)
+        c.mu.Unlock()
+    }, key)
+}
+```
+
+### Timer/Ticker (Go 1.23+)
+
+```go
+// No drain needed before Reset (Go 1.23+)
+t := time.NewTimer(5 * time.Second)
+// ... later ...
+t.Stop()
+t.Reset(10 * time.Second)
+<-t.C
+
+// time.After in loops is safe (GC-eligible, Go 1.23+)
+for {
+    select {
+    case v := <-ch:
+        process(v)
+    case <-time.After(timeout):
+        log.Warn("timeout")
+    case <-ctx.Done():
+        return
+    }
+}
+```
+
+---
+
+## Cryptography
+
+### Random Token Generation (Go 1.24+)
+
+```go
+import "crypto/rand"
+
+token := rand.Text()  // base32, 128+ bits of randomness
+// Use for session tokens, API keys, CSRF tokens
+```
+
+### Reader-less Crypto (Go 1.26+)
+
+```go
+// All these now ignore the rand parameter -- pass nil
+key, _ := ecdsa.GenerateKey(elliptic.P256(), nil)
+key, _ := rsa.GenerateKey(nil, 2048)
+key, _ := ecdh.P256().GenerateKey(nil)
+prime, _ := rand.Prime(nil, 64)
+```
+
+### SHA-3 (Go 1.24+)
+
+```go
+import "crypto/sha3"
+
+hash := sha3.Sum256(data)
+
+// SHAKE XOF
+shake := sha3.NewShake256()
+shake.Write(data)
+output := make([]byte, 64)
+shake.Read(output)
+```
+
+### HKDF and PBKDF2 (Go 1.24+)
+
+```go
+import "crypto/hkdf"
+import "crypto/pbkdf2"
+
+// Key derivation
+key := hkdf.Key(sha256.New, secret, salt, info, 32)
+
+// Password hashing
+dk := pbkdf2.Key([]byte(password), salt, 600000, 32, sha256.New)
+```
+
+### GCM with Random Nonce (Go 1.24+)
+
+```go
+import "crypto/cipher"
+
+block, _ := aes.NewCipher(key)
+aead, _ := cipher.NewGCMWithRandomNonce(block)
+// Nonce auto-generated and prepended
+ciphertext := aead.Seal(nil, nil, plaintext, aad)
+// Decrypt
+plaintext, _ := aead.Open(nil, nil, ciphertext, aad)
+```
+
+### HPKE (Go 1.26+)
+
+```go
+import "crypto/hpke"
+
+kem, kdf, aead := hpke.MLKEM768X25519(), hpke.HKDFSHA256(), hpke.AES256GCM()
+
+// Encrypt
+ciphertext, _ := hpke.Seal(publicKey, kdf, aead, info, plaintext)
+
+// Decrypt
+plaintext, _ := hpke.Open(privateKey, kdf, aead, info, ciphertext)
+```
+
+---
+
+## Filesystem
+
+### os.Root (Go 1.24+, expanded Go 1.25+)
+
+```go
+root, err := os.OpenRoot("/var/data")
+if err != nil {
+    return err
+}
+defer root.Close()
+
+// Read/Write
+data, _ := root.ReadFile("config.json")
+root.WriteFile("output.json", data, 0o644)
+
+// Directory operations
+root.MkdirAll("a/b/c", 0o755)
+root.RemoveAll("temp")
+
+// File operations
+root.Rename("old.txt", "new.txt")
+root.Chmod("file.txt", 0o600)
+root.Link("src.txt", "link.txt")
+root.Symlink("target", "link")
+target, _ := root.Readlink("link")
+
+// Path traversal blocked
+_, err = root.Open("../etc/passwd")  // error
+
+// Get fs.FS interface
+fsys := root.FS()
+```
+
+### os.CopyFS (Go 1.23+)
+
+```go
+// Copy embedded FS to disk
+//go:embed templates
+var templates embed.FS
+os.CopyFS("/var/templates", templates)
+
+// Copy directory
+src := os.DirFS("/source")
+os.CopyFS("/destination", src)
+```
+
+---
+
+## Logging
+
+### slog.DiscardHandler (Go 1.24+)
+
+```go
+logger := slog.New(slog.DiscardHandler)
+```
+
+### slog.NewMultiHandler (Go 1.26+)
+
+```go
+jsonHandler := slog.NewJSONHandler(os.Stdout, nil)
+fileHandler := slog.NewTextHandler(logFile, nil)
+logger := slog.New(slog.NewMultiHandler(jsonHandler, fileHandler))
+```
+
+### slog.GroupAttrs (Go 1.25+)
+
+```go
+attrs := []slog.Attr{
+    slog.String("method", "GET"),
+    slog.Int("status", 200),
+}
+logger.Info("request", slog.GroupAttrs("http", attrs...))
+```
+
+---
+
+## Modules and Tooling
+
+### Tool Directives (Go 1.24+)
+
+```bash
+# Add tool dependency
+go get -tool golang.org/x/tools/cmd/stringer
+
+# Run tool
+go tool stringer -type=Color
+
+# go.mod shows:
+# tool golang.org/x/tools/cmd/stringer
+```
+
+### go fix Modernization (Go 1.26+)
+
+```bash
+# Modernize all code
+go fix ./...
+
+# Only specific fixers
+go fix -rangeint -slicescontains ./...
+
+# Preview changes without applying
+go fix -diff ./...
+```
+
+Key fixers: `rangeint`, `bloop`, `waitgroup`, `omitzero`, `slicescontains`,
+`slicessort`, `minmax`, `stringscut`, `stringsseq`, `forvar`, `newexpr`.
+
+### //go:fix inline (Go 1.26+)
+
+```go
+// Deprecated: Use NewFoo instead.
+//
+//go:fix inline
+func OldFoo() *Foo {
+    return NewFoo()
+}
+// go fix will replace OldFoo() calls with NewFoo()
+```
+
+---
+
+## Reflection
+
+### Type/Value Iterators (Go 1.26+)
+
+```go
+// Iterate struct fields
+typ := reflect.TypeFor[MyStruct]()
+for f := range typ.Fields() {
+    fmt.Println(f.Name, f.Type)
+}
+
+// Iterate methods
+for m := range typ.Methods() {
+    fmt.Println(m.Name, m.Type)
+}
+
+// Iterate function parameters
+fnType := reflect.TypeFor[func(int, string) error]()
+for p := range fnType.Ins() {
+    fmt.Println(p.Name())
+}
+
+// Value iteration (yields both type info and value)
+val := reflect.ValueOf(myStruct)
+for f, v := range val.Fields() {
+    fmt.Printf("%s = %v\n", f.Name, v.Interface())
+}
+```
+
+### reflect.TypeAssert (Go 1.25+)
+
+```go
+val := reflect.ValueOf(someInterface)
+if person, ok := reflect.TypeAssert[Person](val); ok {
+    fmt.Println(person.Name)
+}
+```
+
+---
+
+## Performance Patterns
+
+### bytes.Buffer.Peek (Go 1.26+)
+
+```go
+buf := bytes.NewBufferString("hello world")
+sample, err := buf.Peek(5)  // "hello" without advancing
+// sample is valid until next read/write on buf
+```
+
+### Pointer Initialization with new(expr) (Go 1.26+)
+
+```go
+type Config struct {
+    Port    *int    `json:"port"`
+    Debug   *bool   `json:"debug"`
+    Timeout *string `json:"timeout"`
+}
+
+cfg := Config{
+    Port:    new(8080),
+    Debug:   new(true),
+    Timeout: new("30s"),
+}
+```
+
+### slices.Concat (Go 1.22+)
+
+```go
+result := slices.Concat(s1, s2, s3)  // concatenate multiple slices
+```
+
+### slices.Repeat (Go 1.23+)
+
+```go
+pattern := slices.Repeat([]byte{0xFF, 0x00}, 4)
+// [0xFF, 0x00, 0xFF, 0x00, 0xFF, 0x00, 0xFF, 0x00]
+```


### PR DESCRIPTION
## Summary

- Add Agent Skills-compatible `SKILL.md` enforcing modern Go idioms for Go 1.22 through 1.26
- Add `references/MODERN-PATTERNS.md` with detailed code examples for every pattern
- Add `references/DEPRECATED.md` with full deprecation, GODEBUG, and compatibility reference

## What's included

**SKILL.md (664 lines, self-contained):**
- 16 critical rules for modern Go
- "Do This, Not That" tables across 8 categories (language, stdlib, errors, HTTP, testing, crypto, filesystem, concurrency)
- 28 inline code examples covering every major pattern
- Feature availability matrix for Go 1.22, 1.23, 1.24, 1.25, 1.26
- JSON (omitzero, v2), HTTP routing, timer/ticker, GODEBUG, and performance sections

**references/MODERN-PATTERNS.md (825 lines):**
- Deep-dive code examples organized by topic
- Covers: iterators, synctest, weak pointers, json/v2 streaming, HPKE, os.Root, reflect iterators

**references/DEPRECATED.md (332 lines):**
- All deprecated APIs with replacements (math/rand, SetFinalizer, crypto, HTTP)
- Complete GODEBUG settings table for all versions
- GOEXPERIMENT flags and their lifecycle
- Breaking behavioral changes, security minimums, notable CVEs from patch releases

## Research methodology

8 sub-agents researched in parallel: Go 1.22 patches (12 releases, 17 CVEs), Go 1.23 patches (12 releases, 14 CVEs), Go 1.24 patches (13 releases, 29 CVEs), Go 1.25 patches (7 releases, ~20 CVEs), Go 1.26 RC status, all deprecations across versions, and modern best practices.

Closes #1